### PR TITLE
Replaced DioError and DioErrorType with DioException and DioException…

### DIFF
--- a/lib/src/managers/http/custom_http_client_impl.dart
+++ b/lib/src/managers/http/custom_http_client_impl.dart
@@ -35,8 +35,8 @@ class CustomHttpClientImpl implements CustomHttpClient {
         ),
         onReceiveProgress: onReceiveProgress,
       );
-    } on DioError catch (e) {
-      if (e.type == DioErrorType.cancel) {
+    } on DioException catch (e) {
+      if (e.type == DioExceptionType.cancel) {
         throw DownloadAssetsException(
           e.toString(),
           exception: e,


### PR DESCRIPTION
DioError and DioErrorType are soon to be deprecated for the upcoming Dio 6.