### PR TITLE
Ability to specify custom file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,10 @@ You can now specify the file name and extension with the AssetUrl class in case 
 class AssetUrl {
   final String url;
   final String? fileName;
-  final String? extenstion;
 
   AssetUrl({
     required this.url,
     this.fileName,
-    this.extenstion,
   });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ resources in your app, providing a smooth and efficient user experience.
 Init method for setting up the assetsDir, which is required to be called during app
 initialization.
 
-```
+```dart
 await downloadAssetsController.init();
 ```
 
@@ -27,7 +27,7 @@ await downloadAssetsController.init();
 
 Starts the asset download process.
 
-* *assetsUrls*: A list of URLs representing each file to be downloaded.
+* *assetsUrls*: A list of [AssetUrl] objects representing each file to be downloaded.
 * *uncompressDelegates*: A list of custom decompression delegates for different types of file, such
   as ZIP, RAR, etc (optional).
 * *onStartUnziping*: Called right before the start of the uncompressing process (optional).
@@ -37,16 +37,16 @@ Starts the asset download process.
 * *requestQueryParams*: Query params to be used in the request (optional).
 * *requestExtraHeaders*: Extra headers to be added in the request (optional).
 
-```
+```dart
 await downloadAssetsController.startDownload(
     onCancel: () {
         //TODO: implement cancel here
     },
     assetsUrls: [
-      'https://github.com/edjostenes/download_assets/raw/main/download/image_1.png',
-      'https://github.com/edjostenes/download_assets/raw/main/download/assets.zip',
-      'https://github.com/edjostenes/download_assets/raw/main/download/image_2.png',
-      'https://github.com/edjostenes/download_assets/raw/main/download/image_3.png',
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_1.png'),
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/assets.zip'),
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_2.png'),
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_3.png'),
     ],
     onProgress: (progressValue) {
         //TODO: Implement progress here
@@ -57,11 +57,29 @@ await downloadAssetsController.startDownload(
 );
 ```
 
+### *AssetUrl*
+
+You can now specify the file name and extension with the AssetUrl class in case you don't have control over the URL format.
+
+```dart
+class AssetUrl {
+  final String url;
+  final String? fileName;
+  final String? extenstion;
+
+  AssetUrl({
+    required this.url,
+    this.fileName,
+    this.extenstion,
+  });
+}
+```
+
 ### *clearAssets*
 
 Remove all downloaded assets from local storage.
 
-```
+```dart
 await downloadAssetsController.clearAssets();
 ```
 
@@ -69,7 +87,7 @@ await downloadAssetsController.clearAssets();
 
 Path to the files.
 
-```
+```dart
 File('${downloadAssetsController.assetsDir}/<file_name>.<file_extension>');
 ```
 
@@ -77,7 +95,7 @@ File('${downloadAssetsController.assetsDir}/<file_name>.<file_extension>');
 
 Returns **true** if the **assetsDir** path exists.
 
-```
+```dart
 return await downloadAssetsController.assetsDirAlreadyExists();
 ```
 
@@ -85,7 +103,7 @@ return await downloadAssetsController.assetsDirAlreadyExists();
 
 Return **true** if the file exists.
 
-```
+```dart
 return await downloadAssetsController.assetsFileExists(<file_name>);
 ```
 
@@ -97,7 +115,7 @@ multiple file formats during the download.
 
 To implement your own uncompression delegate, you should implement the interface below.
 
-```
+```dart
 /// Abstract class representing a delegate for asset decompression.
 abstract class UncompressDelegate {
   const UncompressDelegate();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -147,10 +147,10 @@ class _MyHomePageState extends State<MyHomePage> {
             setState(() {});
           },
           assetsUrls: [
-            'https://github.com/edjostenes/download_assets/raw/main/download/image_1.png',
-            'https://github.com/edjostenes/download_assets/raw/main/download/assets.zip',
-            'https://github.com/edjostenes/download_assets/raw/main/download/image_2.png',
-            'https://github.com/edjostenes/download_assets/raw/main/download/image_3.png',
+            AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_1.png'),
+            AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/assets.zip'),
+            AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_2.png'),
+            AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_3.png'),
           ],
           onProgress: (progressValue) {
             value = progressValue;

--- a/lib/src/download_assets_controller.dart
+++ b/lib/src/download_assets_controller.dart
@@ -3,6 +3,13 @@ import 'managers/file/file_manager_impl.dart';
 import 'managers/http/custom_http_client_impl.dart';
 import 'uncompress_delegate/uncompress_delegate.dart';
 
+class AssetUrl {
+  const AssetUrl({required this.url, this.fileName});
+
+  final String url;
+  final String? fileName;
+}
+
 abstract class DownloadAssetsController {
   factory DownloadAssetsController() => createObject(
         fileManager: FileManagerImpl(),
@@ -43,7 +50,7 @@ abstract class DownloadAssetsController {
   /// [requestQueryParams] -> Query params to be used in the request (optional)
   /// [requestExtraHeaders] -> Extra headers to be added in the request (optional)
   Future startDownload({
-    required List<String> assetsUrls,
+    required List<AssetUrl> assetsUrls,
     List<UncompressDelegate> uncompressDelegates = const [UnzipDelegate()],
     Function(double)? onProgress,
     Function()? onStartUnziping,

--- a/lib/src/download_assets_controller.dart
+++ b/lib/src/download_assets_controller.dart
@@ -49,6 +49,7 @@ abstract class DownloadAssetsController {
   /// [onCancel] -> Cancel the download (optional)
   /// [requestQueryParams] -> Query params to be used in the request (optional)
   /// [requestExtraHeaders] -> Extra headers to be added in the request (optional)
+  /// [checkSize] -> Speicifies if the size of the file should be checked first before starting download
   Future startDownload({
     required List<AssetUrl> assetsUrls,
     List<UncompressDelegate> uncompressDelegates = const [UnzipDelegate()],
@@ -58,6 +59,7 @@ abstract class DownloadAssetsController {
     Function()? onDone,
     Map<String, dynamic>? requestQueryParams,
     Map<String, String> requestExtraHeaders = const {},
+    bool? checkSize = true,
   });
 
   /// Cancel the download

--- a/lib/src/download_assets_controller_impl.dart
+++ b/lib/src/download_assets_controller_impl.dart
@@ -75,6 +75,7 @@ class DownloadAssetsControllerImpl implements DownloadAssetsController {
     Function()? onDone,
     Map<String, dynamic>? requestQueryParams,
     Map<String, String> requestExtraHeaders = const {},
+    bool? checkSize = true,
   }) async {
     assert(assetsDir != null, 'DownloadAssets has not been initialized. Call init method first');
     assert(assetsUrls.isNotEmpty, "AssetUrl param can't be empty");
@@ -94,8 +95,10 @@ class DownloadAssetsControllerImpl implements DownloadAssetsController {
           fullPath: fullPath,
           extenstion: extension(assetUrl.fileName ?? assetUrl.url),
         ));
-        final size = await customHttpClient.checkSize(assetUrl.url);
-        totalSize += size;
+
+        if (checkSize == true) {
+          totalSize += await customHttpClient.checkSize(assetUrl.url);
+        }
       }
 
       final downloadedBytesPerAsset = <String, int>{};

--- a/lib/src/download_assets_controller_impl.dart
+++ b/lib/src/download_assets_controller_impl.dart
@@ -82,7 +82,7 @@ class DownloadAssetsControllerImpl implements DownloadAssetsController {
     try {
       onProgress?.call(0.0);
       await fileManager.createDirectory(_assetsDir!);
-      var totalSize = 0;
+      var totalSize = -1;
       var downloadedSize = 0;
       final assets = <({String assetUrl, String fullPath, String extenstion})>[];
 
@@ -111,7 +111,6 @@ class DownloadAssetsControllerImpl implements DownloadAssetsController {
 
             final previousReceived = downloadedBytesPerAsset[asset.fullPath] ?? 0;
             downloadedSize += received - previousReceived;
-            downloadedSize = downloadedSize.clamp(0, totalSize);
             downloadedBytesPerAsset[asset.fullPath] = received;
             final progress = downloadedSize / totalSize;
             onProgress?.call(progress);

--- a/lib/src/download_assets_controller_impl.dart
+++ b/lib/src/download_assets_controller_impl.dart
@@ -108,9 +108,9 @@ class DownloadAssetsControllerImpl implements DownloadAssetsController {
           asset.assetUrl,
           asset.fullPath,
           onReceiveProgress: (int received, int total) {
-            if (total == -1 || received <= 0) {
+            /*if (total == -1 || received <= 0) {
               return;
-            }
+            }*/
 
             final previousReceived = downloadedBytesPerAsset[asset.fullPath] ?? 0;
             downloadedSize += received - previousReceived;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: download_assets
 description: Retrieve assets and add them to the application's repository for use.
-version: 3.2.0
+version: 4.0.0
 homepage: https://github.com/edjostenes/download_assets
 
 environment:

--- a/test/src/download_assets_controller_test.dart
+++ b/test/src/download_assets_controller_test.dart
@@ -200,10 +200,16 @@ void main() {
 
   group('startDownload', () {
     final assetsUrls = [
-      'https://github.com/edjostenes/download_assets/raw/main/download/image_1.png',
-      'https://github.com/edjostenes/download_assets/raw/main/download/assets.zip',
-      'https://github.com/edjostenes/download_assets/raw/main/download/image_2.png',
-      'https://github.com/edjostenes/download_assets/raw/main/download/image_3.png',
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_1.png'),
+      AssetUrl(
+        url: 'https://github.com/edjostenes/download_assets/raw/main/download/assets.zip',
+      ),
+      AssetUrl(
+        url: 'http://bit.ly/3AUO9Pc',
+        fileName: 'assets_1.zip',
+      ), // same file as above
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_2.png'),
+      AssetUrl(url: 'https://github.com/edjostenes/download_assets/raw/main/download/image_3.png'),
     ];
     Future<Response> customHttpClientDownload() => customHttpClient.download(
           any(),
@@ -239,8 +245,8 @@ void main() {
 
         // then
         verify(() => fileManager.createDirectory(any())).called(1);
-        verify(() => customHttpClient.checkSize(any())).called(4);
-        verify(() => customHttpClientDownload()).called(4);
+        verify(() => customHttpClient.checkSize(any())).called(5);
+        verify(() => customHttpClientDownload()).called(5);
         verifyNoMoreInteractions(customHttpClient);
         verifyNoMoreInteractions(fileManager);
       },
@@ -268,7 +274,7 @@ void main() {
           throwsA(isA<DownloadAssetsException>()),
         );
         verify(() => fileManager.createDirectory(any())).called(1);
-        verify(() => customHttpClient.checkSize(any())).called(4);
+        verify(() => customHttpClient.checkSize(any())).called(5);
         verify(() => customHttpClientDownload()).called(1);
         verifyNoMoreInteractions(customHttpClient);
         verifyNoMoreInteractions(fileManager);


### PR DESCRIPTION
I had an issue where i had no control over the url format, and the file i wanted to download was a zip. So i needed a way to specify a custom filename alongside the url.

So i added a `AssetUrl` class to handle this, it's a breaking change, upgraded the version to 4.0.0

So instead of checking for the zip extension from the url, it checks from the specified file name